### PR TITLE
Fix issue with escaping spaces

### DIFF
--- a/git-praise
+++ b/git-praise
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-git blame $@
+git blame "$@"


### PR DESCRIPTION
Without the quotes the arguments are split at spaces which will do the wrong thing for instance for file names with spaces in them.
