### PR TITLE
Remove -e

### DIFF
--- a/git-praise
+++ b/git-praise
@@ -1,2 +1,2 @@
-#!/usr/bin/env sh -e
+#!/usr/bin/env sh
 exec git blame "$@"


### PR DESCRIPTION
env attempts to launch a process called `/bin/sh -e` which does not exist
env could split the arguments with `env -S`, but there's no need, because after exec the error code is coming from git